### PR TITLE
feat: windows prefill for powershell/conhost/terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ This type is for any other OpenAI-compatible API endpoint, such as Ollama, LM St
     If not found, it falls back to Unix-like history files that may exist when using Git Bash/MSYS/Cygwin (e.g., `.bash_history`, `.zsh_history`).
 - **Directory listing**: On Windows, directory listing uses `dir /b`; on Linux/macOS it uses `ls`.
 
-### 5. Add the `uwu` helper function to your `~/.zshrc`
+### 5. Configure the `uwu` helper function
 
 This function lets you type `uwu <description>` and get an editable command preloaded in your shell.
+
+#### zsh
 
 ```zsh
 # ~/.zshrc
@@ -218,12 +220,91 @@ uwu() {
 }
 ```
 
+#### Powershell / Conhost / Windows Terminal
+
+Note: This only applies to Windows with Powershell installed
+
+To your Powershell profile, add this snippet
+
+```Powershell
+function uwu {
+    param(
+        [Parameter(ValueFromRemainingArguments=$true)]
+        $args
+    )
+    $Source = '
+    using System;
+    using System.Runtime.InteropServices;
+
+    public class ConsoleInjector {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KEY_EVENT_RECORD {
+            public bool bKeyDown;
+            public ushort wRepeatCount;
+            public ushort wVirtualKeyCode;
+            public ushort wVirtualScanCode;
+            public char UnicodeChar;
+            public uint dwControlKeyState;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INPUT_RECORD {
+            public ushort EventType;
+            public KEY_EVENT_RECORD KeyEvent;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool WriteConsoleInput(
+            IntPtr hConsoleInput,
+            INPUT_RECORD[] lpBuffer,
+            int nLength,
+            out int lpNumberOfEventsWritten
+        );
+
+        const int STD_INPUT_HANDLE = -10;
+        const ushort KEY_EVENT = 0x0001;
+
+        public static void SendCommand(string text) {
+            IntPtr hIn = GetStdHandle(STD_INPUT_HANDLE);
+            var records = new INPUT_RECORD[text.Length];
+            
+            int i = 0;
+            for (; i < text.Length; i++) {
+                records[i].EventType = KEY_EVENT;
+                records[i].KeyEvent.bKeyDown = true;
+                records[i].KeyEvent.wRepeatCount = 1;
+                records[i].KeyEvent.UnicodeChar = text[i];
+            }
+
+            int written;
+            WriteConsoleInput(hIn, records, i, out written);
+        }
+    }';
+    $cmd = uwu-cli @args;
+    Add-Type -TypeDefinition $Source;
+    [ConsoleInjector]::SendCommand($cmd)
+}
+```
+
+This will work for Powershell terminals. To add this functionality to Conhost / Terminal, save this as `uwu.bat` and let it be accessible in ```PATH``` (you must do the Powershell step as well). For example,
+
+```Batch
+:: assumes that ECHO ON and CHCP 437 is user preference
+@ECHO OFF
+CHCP 437 >NUL
+POWERSHELL uwu %*
+@ECHO ON
+```
+
 ## Usage
 
 Once installed and configured:
 
 ```bash
-uwu generate a new ssh key called uwu-keyand add it to the ssh agent
+uwu generate a new ssh key called uwu-key and add it to the ssh agent
 ```
 
 You'll see the generated command in your shell's input line. Press **Enter** to run it, or edit it first. Executed commands will show up in your shell's history just like any other command.


### PR DESCRIPTION
I saw https://github.com/context-labs/uwu/issues/11 and created very simple snippet to prefill commands.

Tested on Powershell Terminal, Conhost, and Windows Terminal version 1.22.12111