### PR TITLE
feat: add a auto copy to clipboard feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,30 @@ This type is for any other OpenAI-compatible API endpoint, such as Ollama, LM St
 - `maxHistoryCommands`: Number of recent commands to include (default: `10`)
   When enabled, `uwu` automatically detects and parses history from bash, zsh, and fish shells.
 
+---
+
+#### Clipboard Configuration (Optional)
+
+`uwu` can automatically copy generated commands to your system clipboard. This feature is enabled by default but can be disabled:
+
+```json
+{
+  "type": "OpenAI",
+  "apiKey": "sk-your_api_key",
+  "model": "gpt-4.1",
+  "clipboard": true
+}
+```
+
+- `clipboard`: Whether to automatically copy commands to clipboard (default: `true`)
+
+The clipboard feature works cross-platform:
+- **macOS**: Uses `pbcopy`
+- **Linux**: Uses `xclip` (with `xsel` as fallback)
+- **Windows**: Uses `clip`
+
+If clipboard copying fails, `uwu` will show a warning but continue normal operation.
+
 ##### Notes on history scanning performance
 
 - **Chunk size unit**: When scanning shell history files, `uwu` reads from the end of the file in fixed-size chunks of 64 KiB. This is not currently configurable but can be made if desired.

--- a/sample_configs/github.json
+++ b/sample_configs/github.json
@@ -1,6 +1,7 @@
 {
-  "type": "GitHub",
-  "apiKey": "your-github-token",
-  "model": "model-available-at-https://github.com/marketplace/models/",
-  "baseURL": "https://models.github.ai/inference"
+    "type": "GitHub",
+    "apiKey": "your-github-token",
+    "model": "model-available-at-https://github.com/marketplace/models/",
+    "baseURL": "https://models.github.ai/inference",
+    "clipboard": true
 }

--- a/sample_configs/ollama.json
+++ b/sample_configs/ollama.json
@@ -2,5 +2,6 @@
   "type": "Custom",
   "model": "llama3",
   "baseURL": "http://localhost:11434/v1",
-  "apiKey": "ollama"
+  "apiKey": "ollama",
+  "clipboard": true
 }

--- a/sample_configs/openai.json
+++ b/sample_configs/openai.json
@@ -1,5 +1,6 @@
 {
   "type": "OpenAI",
   "apiKey": "sk-your_openai_api_key",
-  "model": "gpt-4.1"
+  "model": "gpt-4.1",
+  "clipboard": true
 }


### PR DESCRIPTION
### PR Summary: Add Automatic Clipboard Copy Feature

## Overview

Added automatic clipboard copying to `uwu` CLI. Generated commands are now automatically copied to the system clipboard.

## Implementation

- **Cross-platform clipboard support**: Uses `pbcopy` (macOS), `xclip`/`xsel` (Linux), and `clip` (Windows)
- **New config option**: Added `clipboard` boolean field, defaults to `true`
- **Error handling**: Shows warnings if clipboard operations fail but continues normal operation
- **Non-breaking**: Existing configs work unchanged

## Code Changes

- Added `clipboard?: boolean` to `Config` interface  
- Added `copyToClipboard()` function using `Bun.spawn()` for process execution
- Updated main execution to copy command before console output
- Enhanced sample configs and documentation

## Usage

Works automatically with existing workflows. To disable, add `"clipboard": false` to your config:

```json
{
  "type": "Custom", 
  "model": "gemma3:1b",
  "baseURL": "http://localhost:11434/v1",
  "clipboard": false
}
```

This makes it easier to use generated commands - they're immediately available for pasting without manual copying.