### PR TITLE
chore: update readme with correct defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This will produce the `uwu-cli` binary in the `dist/` build output directory.
 
 ```bash
 chmod +x dist/uwu-cli
-mv dist/uwu-cli /usr/local/bin/uwu-cli
+mv dist/uwu-cli /usr/local/bin/uwu
 ```
 
 ### 4. Configuration
@@ -125,7 +125,7 @@ Uses the native Google Gemini API.
 {
   "type": "Gemini",
   "apiKey": "your-google-api-key",
-  "model": "gemini-pro"
+  "model": "gemini-2.5-pro"
 }
 ```
 

--- a/sample_configs/gemini.json
+++ b/sample_configs/gemini.json
@@ -1,5 +1,5 @@
 {
-  "type": "Gemini",
-  "apiKey": "your-google-api-key",
-  "model": "gemini-pro"
+    "type": "Gemini",
+    "apiKey": "your-google-api-key",
+    "model": "gemini-2.5-pro"
 }

--- a/sample_configs/gemini.json
+++ b/sample_configs/gemini.json
@@ -1,5 +1,5 @@
 {
-    "type": "Gemini",
-    "apiKey": "your-google-api-key",
-    "model": "gemini-2.5-pro"
+  "type": "Gemini",
+  "apiKey": "your-google-api-key",
+  "model": "gemini-2.5-pro"
 }


### PR DESCRIPTION
# Summary

Readme has some issues that may make it difficult for some users to get started. 

Fixed mv command renaming uwu-cli to uwu after moving. 

Fixed invalid model name in gemini config in Readme and sample config.